### PR TITLE
[use-cases] issuing updates

### DIFF
--- a/specs/source/use-cases/index.html
+++ b/specs/source/use-cases/index.html
@@ -380,7 +380,6 @@ by the group should address.
             </dd>
             <dd>Related use cases  Other use cases for contact details would include initial create and manage contact details profile, service provider checks for contact details credential change, citizen notifies multiple service providers about a credential change.</dd>
           </dl>
-          <img alt='Example credential creation flow' style='display:block; margin:auto' src="uc-issuing-claims.svg"/>
         </section>
 
         <section>
@@ -410,7 +409,6 @@ by the group should address.
               that Jane has an account at MidBank and has access to her associated
               checking account.</dd>
           </dl>
-          <img alt='Example credential creation flow' style='display:block; margin:auto' src="uc-issuing-claims.svg"/>
         </section>
       </section>
 

--- a/specs/source/use-cases/index.html
+++ b/specs/source/use-cases/index.html
@@ -317,6 +317,7 @@ by the group should address.
               (<a>issuer</a>) that she can use to prove to the officer
               (<a>credential consumer</a>) that her <a>claim</a> is
               valid.
+              <img alt='Example credential creation flow' style='display:block; margin:auto' src="uc-issuing-claims.svg"/>
             </dd>
             <dd>Jane would like to get a digitally signed credential for her checking
               account at MidBank. MidBank offers to provide a credential asserting
@@ -336,7 +337,6 @@ by the group should address.
               exists. Finally it presents the eTextbook contents to the
               student.</dd>
           </dl>
-          <img alt='Example credential creation flow' style='display:block; margin:auto' src="uc-issuing-claims.svg"/>
         </section>
 
         <section>
@@ -383,31 +383,18 @@ by the group should address.
         </section>
 
         <section>
-          <h3 id="uc-issuing-lti">Learning Tools Interoperability</h3>
+          <h3 id="uc-issuing-lti">Delegating Credential Creating</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
-            <dd>It MUST be possible for anyone to issue a verifiable claim.</dd>
+            <dd>It MUST be possible for an <a>issuer</a> to delegate issuing credentials to end users.</dd>
             <dt>Motivation</dt>
-            <dd>An <a>entity</a>, such as an end user (<a>holder</a>),
-              wishes to make a <a>claim</a> and would like it to be endorsed by a
-              different <a>entity</a> (<a>issuer</a>) which may be trusted by
-              potiential consumer (<a>credential consumer</a>).</dd>
+            <dd>An <a>issuer</a> would like to provide credentials for end users while delegating the technical aspects of this to a third party. A credential authority would be able to authorize 1 or more credential issuers which would in turn be able to issue secure credentials that are accepted as valid and acceptable by consumers of the authority's credentials.</dd>
             <dt>Phase</dt>
-            <dd>Essential.</dd>
+            <dd>Nice to have.</dd>
             <dt>Scenarios</dt>
-            <dd>Asako just passed the final test to receive a drivers
-              license. As she is still a new driver, and may be pulled over
-              for a traffic violation, she would like to receive a verfiable
-              claim that she has right to drive a car (<a>claim</a>). She
-              requests a verifiable claim from the certifying authority
-              (<a>issuer</a>) that she can use to prove to the officer
-              (<a>credential consumer</a>) that her <a>claim</a> is
-              valid.
-            </dd>
-            <dd>Jane would like to get a digitally signed credential for her checking
-              account at MidBank. MidBank offers to provide a credential asserting
-              that Jane has an account at MidBank and has access to her associated
-              checking account.</dd>
+            <dd>MidBank offers to provide credentials to account holders, such as Jane.
+              CredentialsRUs provides a service for busniesses such as MidBank to use
+              for providing such credentials.</dd>
           </dl>
         </section>
       </section>
@@ -670,7 +657,7 @@ by the group should address.
                   <h1>4. What is the most compelling Credentials use case that your organization would like to see better integrated into the Web that would be helped by one or more new standards in the space?</h1>
                   <p><em>Consuming</em><br>Company would like to be able to attach authenticated user identity to their outcome results for their performance during time at educational institutions using our software to facilitate their learning and assessment.  Company relies on strong identity assertions to prevent fraudulent access to our systems and data, and a standards based approach would lower our need to invent and maintain a proprietary solution to this problem.</p>
                   <hr>
-                  <p><em>Issuing</em><br>Provide an interoperable standard for credentials on the web that allows for delegated issuance of standard web-based credentials to end users of a system.  As an example, a credential authority would be able to authorize 1 or more credential issuers which would in turn be able to issue secure credentials that are accepted as valid and acceptable by consumers of the authorities credentials.</p>
+                  <p><em>Issuing</em><br>Provide an interoperable standard for credentials on the web that allows for delegated issuance of standard web-based credentials to end users of a system.  As an example, a credential authority would be able to authorize 1 or more credential issuers which would in turn be able to issue secure credentials that are accepted as valid and acceptable by consumers of the authorities credentials. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Managing and Sharing</em><br>We would like to let credential earners compose their credentials into representations that meet the needs of particular requestors, such as when job applicants package up a resume for the needs of a certain position opening. We would like to be able to better match up a particular credential against various parties’ needs for credentials, in an expressive way. “I am looking for a candidate who has experience with ‘scrum-based agile software development’”, for example.</p>
                   <hr>

--- a/specs/source/use-cases/index.html
+++ b/specs/source/use-cases/index.html
@@ -296,6 +296,49 @@ by the group should address.
       <section>
         <!-- Editor - @gkellogg -->
         <h2>Issuing Claims</h2>
+
+        <p>The general flow discussed for issuing claims is the following:</p>
+        <p><em><strong>Issuer Advertises Credential Template</strong></em></p>
+        <p>The <a>Issuer</a> publishes a Credential Template elaborating
+          on the requirements that must be completed to issue the
+          <a>credential</a>.</p>
+        <p>The credential definition includes descriptive metadata about
+          the circumstances and context in which the credential is issued to
+          the receipient (<a>holder</a>). The issuer clearly defines this
+          information so others who later view or review the credential can
+          understand the context behind it.</p>
+
+        <p><em><strong>Recipient Proves Suitability for
+          Credential</strong></em></p>
+        <p>A recipient proves that they have met the requirements necessary
+          to acquire the credential from the issuer.</p>
+        <p>The results of tests could be shared more easily if they
+          were produced in the form of a digital credential.</p>
+        <p>Credentials should be able to be issued as a side-effect
+          of performing a particular real-world action.</p>
+
+        <p><em><strong>Issuer Issues Credential to Recipient</strong></em></p>
+        <p>The issuer customizes the credential template for a
+          particular recipient. The credential may be digitally
+          signed.</p>
+        <p>An issuer can make a <a>claim</a> that asserts something specific
+          about the recipient, such as a qualification, attribute, or the
+          attainment of a particular defined achievement.</p>
+        <p>It is important that an issuer ensure that a recipient is
+          who they say they are before issuing important credentials to the
+          recipient.</p>
+        <p>Personally identifiable information must use known data fields
+          in order to enable credential curation services to protect the
+          recipient’s privacy.</p>
+        <p>A credential must be able to be issued to people that
+          have disabilities (10% of the human population)</p>
+
+        <p><em><strong>Recipient Stores Credential</strong></em></p>
+        <p>The recipient stores the credential in a credential vault or
+          other long-term storage location. A recipient of a digital credential
+          may store it on a variety of platforms or media. Credentials MUST be
+          portable.</p>
+
         <section>
           <h3 id="uc-issuing-claims">Issuing Claims</h3>
           <dl class="dl-horizontal">
@@ -343,6 +386,226 @@ by the group should address.
               certain activities necessary to comply with conformance
               requirements e.g. “I have maintained my profession by following
               xyz course.”</dd>
+            <dd>In <abbr title="Massive Open Online Course">MOOC</abbr>
+              and other on-line learning systems being able to reliably
+              identify participants is vital to ensure the individual
+              evaluation and certification. A participant that performs a test
+              certified on the Web must provide his credentials to prove his
+              identity before the test, and then to allow the system to issue a
+              secure certificate of his results to the test.</dd>
+            <dd>We want to enable test takers to have a
+              digital credential that represents a score report for pursuing
+              opportunities in education, workforce, and personal endeavors. We
+              can do point-to-point distribution of score reports with current
+              technologies and standards, but we seek a digital score report
+              credential that will allow a test taker to do controlled,
+              multipoint display and distribution (on LinkedIn, Credly,
+              Parchment, Monster, or Facebook, for example). Such a credential
+              will increase the utility and user control of their score
+              reports. Doing this requires ubiquitous web-based standards of
+              the type being worked on by IMS Global, the W3C Community Group,
+              the Dublin Core, and others to ensure validity, security,
+              privacy, efficient display and consumption, issuer control,
+              protection of intellectual property and business model, and
+              similar requirements.</dd>
+          <dd>
+            <p>There are important pieces of metadata associated with a
+            particular Credential:</p>
+            <ul>
+              <li>Colorado State University is creating several recognition certificates to help foster a campus culture of leadership, tolerance and acceptance. The dean’s office defines the criteria and what evidence is accepted to prove that the recipient has met the criteria.</li>
+              <li>Green Federal Credit Union has performed Know Your Customer clearing (driver’s license, background check, anti-money laundering blackslist check, etc.), on Reece and would like to issue a credential to him for use at other financial institutions.</li>
+              <li>Harper High School teachers define soft skill credentials to award their students, using a web app that has badge defining and issuing features.</li>
+              <li>The Veterans Affairs office is working on an initiative to translate military experience into digitized claims of the veteran’s skills to help veterans better connect with employment when they return from duty.</li>
+              <li>The Project Management Institute which has been issuing Project Management certificates for many years is moving toward digitization of their existing certification program.</li>
+            </ul>
+          </dd>
+          <dd>
+            <ul>
+                <li>A teacher professional development association awards Penny Chen a digital certificate which claims she has fulfilled her professional development units and has demonstrated mastery over common core instruction.</li>
+                <li>Brian is taking an online course on web development. When he completes modules, the website issues badges to him for module completion and progress through the course. At the end of the course he has an option to submit his work and quizzes that are evaluated and then he is issued a badge.</li>
+                <li>The state government of California issues Amari a driver’s license after he passes both the written and practice driving tests.</li>
+                <li>Educause conference issues digital badges to all conference speakers through a claim code system. Conference speakers are given a special code, that they input on the educause site which triggers a badge to be issued to them.</li>
+            </ul>
+          </dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-claims-in-credential">Making Claims in a Credential</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for an <a>issuer</a> make multiple
+              <a>claims</a> in a <a>credential</a>.</dd>
+            <dt>Motivation</dt>
+            <dd>An <a>issuer</a> can make a <a>claim</a> that asserts
+              something specific about the <a>holder</a>, such as a
+              qualification, attribute, or the attainment of a particular
+              defined achievement. Credentials may aggregate multiple claims,
+              and may include additional information to identify the
+              <a>holder</a>.</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>
+              <ul>
+                <li>A teacher professional development association awards Penny Chen a digital certificate which claims she has fulfilled her professional development units and has demonstrated mastery over common core instruction.</li>
+                <li>Brian is taking an online course on web development. When he completes modules, the website issues badges to him for module completion and progress through the course. At the end of the course he has an option to submit his work and quizzes that are evaluated and then he is issued a badge.</li>
+                <li>The state government of California issues Amari a driver’s license after he passes both the written and practice driving tests.</li>
+                <li>Educause conference issues digital badges to all conference speakers through a claim code system. Conference speakers are given a special code, that they input on the educause site which triggers a badge to be issued to them.</li>
+              </ul>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3 id="uc-issuing-identification">Identifying Credential Holders</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for an <a>issuer</a> to verify
+              the <a>identity</a> of a <a>holder</a>. Personally identifiable
+              information must use known data fields in order to enable
+              credential curation services to protect the recipient’s
+              privacy.</dd>
+            <dt>Motivation</dt>
+            <dd>It is important that an <a>issuer</a> ensure that a
+              <a>holder</a> is who they say they are before issuing important
+              credentials.</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>One of the most compelling use cases for Company is issuance
+              of Loyalty Cards. When a customer applies for Loyalty Cards
+              either online or at Point Of Sale (POS), he would need to enclose
+              either SSN or Driving License or State ID. Though there are
+              secure standards implemented in handling the information it would
+              be preferable to avoid sensitive information exchange.</dd>
+            <dd>Company would like to be able to strongly establish a
+              learning identity so that when that individual moves from one
+              institution using our software to another institution using our
+              software (or someone else’s software) that identity and their
+              associated accomplishments can travel with them. We also want to
+              be able to validate that users actually using our system is the
+              same person who registered for courses and will receive
+              credentials during and after assessment.</dd>
+            <dd>Authenticating the people using Fuel Fleet Cards
+              (payment cards) and <abbr title="Automated Clearing
+              House">ACH</abbr>-based payments is also important. Credentialing
+              in both cases is critical and uncontrolled by the card brand.
+              Both are decoupled, and require a payment system to <abbr title="Know Your Customer">KYC</abbr> and other
+              profile information – all without passing that source data
+              around. So in ACH its “I am John Doe, and here is my account
+              information” in a digital token. Closed loop cards as well. ACH
+              is just a set of rails, with no authentication beyond RTA – so
+              credentials are key here (waiting for the first ACH breach to
+              drive that home – with the source accounts drained and Reg E the
+              only remedy).</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-issuing-verifiability">Credential Verifiability</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for a <a>credential consumer</a> to
+              <a data-lt="credential verification">verify credentials</a>
+              as genuine.</dd>
+            <dt>Motivation</dt>
+            <dd>An <a>issuer</a> MUST be able to sign a credential
+              which can be verified by an arbitrary third party (<s>credential
+              consumer</s>).</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>Company creates credential and signs with a private key.
+              Part of the signed data includes the location of the
+              corresponding public key. A third party having received the
+              credential can retrieve the public key and verify that the
+              credential signature is valid. Through other means, they can
+              choose to trust Company as a valid issuer of
+              credentials including claims that they require.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-issuing-personal-information">Including Personally Identifiable Information</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for an <a>issuer</a> to include
+              personally identifable information about a <a>holder</a>.</dd>
+            <dt>Motivation</dt>
+            <dd>In some cases, a <a>claim</a> needs to include other information
+              which can be used to help verifying the <a>identity</a>
+              of the <a>holder</a>.</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>In certain cases, for legal or other reasons,
+              it may be necessary to capture personally identifiable
+              information as part of the credential provisioning process. This
+              would not apply in all cases, but the credential standard would
+              need to optionally allow for the transmission/exchange of this
+              information as part of the provisioning process.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-issuing-unambiguous-naming">Unambiguous Naming</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>Credentials MUST be able to use unambigous names for
+              described entities.</dd>
+            <dt>Motivation</dt>
+            <dd>Many claims systems to not include a mechanism to unambigously identify entities. The interoperability of credentials depends largely on market verticals defining and standardizing common terminology in publicly available machine-readable vocabulary documents.</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>
+              <p>Most (bar WebID-TLS) fail to incorporate unambiguous naming
+                using HTTP URIs. In addition, entity names don’t resolve to
+                entity description documents.</p>
+              <ol>
+                <li>OAuth1 provides assurance of partner identity (Publisher
+                  can trust UCLA is sending the message). But Publisher must
+                  trust the university to accurately identify the user and the
+                  user’s role with respect to the course.</li>
+                <li>OAuth2 loses message verification of OAuth1, but needs
+                  to be partnered with other identification protocols.</li>
+                <li>SAML / Shib gives more highly trusted identity information
+                  than either OAuth but contains no course context (unlike LTI).
+                  It is considered too complicated for most higher-ed
+                  institutions and near-impossible for the burgeoning K-12
+                  market.</li>
+              </ol>
+            </dd>
+            <dd>
+              <ul>
+                <li>Education credentials use a common set of vocabularies to establish a credential type, alignment, and criteria.</li>
+                <li>Healthcare credentials use a common set of terminology to express licensing status, prescription writing authorization, and which medical facilities the recipient has access to enter.</li>
+                <li>Anti-money laundering credentials can be used to report suspicious activity on a global basis by using a common set of terminology to express people and organizations that are engaged in transactions.</li>
+              </ul>
+            </dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-issuing-accessability">Credential Accessability</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for a <a>credential consumer</a>
+              operating in one language to understand credentials issued in a
+              different language. A credential MUST be able to be issued to
+              people that have disabilities (10% of the human population).</dd>
+            <dt>Motivation</dt>
+            <dd>Issuers and Credential Consumers often operate in
+              different languages, and the basis of the credential MUST be
+              described in a way which supports interpreting it in multiple
+              language.</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>Company creates a credential with claims.
+              Such claims need to either be described in multiple languages, or
+              the claim definition allows an indirection to describe the claim
+              in different languages.</dd>
           </dl>
         </section>
 
@@ -355,10 +618,15 @@ by the group should address.
             <dt>Motivation</dt>
             <dd>An <a>entity</a>, such as an end user (<a>holder</a>),
               wishes to make a <a>claim</a> and which they endorse themselves,
-              acting as an <a>issuer</a>.</dd>
+              such as a qualification, attribute, or the attainment of a
+              particular defined achievement, acting as an <a>issuer</a>.</dd>
             <dt>Phase</dt>
             <dd>Nice to have.</dd>
             <dt>Scenarios</dt>
+            <dd>Mandy has years of experience as a web developer but as an
+              autodidact, doesn’t have the credentials to prove it when
+              applying for jobs. Mandy issues herself a credential and includes
+              information/evidence to support her claim.</dd>
             <dd>
               <p>Purpose  The Country Government does not want to build a
                 centralised repository for citizen’s self-asserted credentials
@@ -432,11 +700,79 @@ by the group should address.
         </section>
 
         <section>
+          <h3 id="uc-issuing-bearer-credentials">Bearer Credentials</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible to prove that a <a>holder</a> has a
+              particular <a>claim</a> without leaking personally identifiable
+              information.</dd>
+            <dt>Motivation</dt>
+            <dd>Two colluding websites should not be able to collude and build
+              a more accurate profile of a person. There are many problems with
+              this privacy requirement. Namely, the Open Web Platform provides
+              multiple mechanisms like session tracking, supercookies, and
+              email-based identifiers, that enable colluding websites to track
+              their users across the Web. Given these existing tracking
+              mechanisms, a bearer credential solution shouldn’t make the
+              problem worse.</dd>
+            <dt>Phase</dt>
+            <dd>Nice to have.</dd>
+            <dt>Scenarios</dt>
+            <dd>Niambo would like to prove that she is over the age of 13
+              to get access to a protected website. She has a proof of age
+              credential that can be used in a pseudo-anonymous fashion. She
+              proves her age pseudo-anonymously, as the credential consumer
+              website does not want to track its users, but does want to ensure
+              that it is compliant from a regulatory perspective.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-identifier-aliasing">Identifier Aliasing</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>A <a>holder</a> MUST be able to claim <a>credentials</a>
+              issued to different identifiers owned by the <a>holder</a>.</dd>
+            <dt>Motivation</dt>
+            <dd>A <a>holder</a> may collect credentials asserting that
+              multiple identifiers correspond to their <a>identity</a> so that
+              they may present credentials issued to several of these
+              identifiers at once, as long as the <a data-lt="credential
+              consumer">consumer</a> of that statement trusts each of the
+              equivalence credential <a>issuers</a>.</dd>
+            <dt>Phase</dt>
+            <dd>Nice to have.</dd>
+            <dt><em>Security</em></dt>
+            <dd>When sharing email accounts, forging credentials becomes
+              easier/more commonplace. There are also accidental information
+              leakage issues w/ shared credentials.</dd>
+            <dt>Scenarios</dt>
+            <dd>Owen received a number of credentials issued to an
+              employment-based identifier and uses an identifier equivalence
+              credential issued by his employer to bundle these together with
+              credentials issued to a personal identifier so that consumers
+              will trust the different credentials were issued to the same
+              recipient.</dd>
+            <dd>Sally was issued a credential from her former high school to
+              her then school email, sally@losalamitoshigh.edu. Sally has since
+              transferred to a new high school and wants to be able to claim
+              that credential still as hers even if her former high school
+              email is no longer valid.</dd>
+            <dd>When Jabar was 12, he took several online courses on
+              Khan Academy using his parent’s or teacher’s emails, due to COPPA
+              regulations that didn’t allow him to create his own account.
+              During that period he earned various badges and certificates
+              which, now that he’s 13, he’d like to claim under his own email
+              address.</dd>
+          </dl>
+        </section>
+
+        <section>
           <h3 id="uc-issuing-delegation">Delegating Credential Creation</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
             <dd>It MUST be possible for an <a>issuer</a> to
-              delegate issuing credentials to end users.</dd>
+              delegate issuing credentials to end users (<a>holder</a>).</dd>
             <dt>Motivation</dt>
             <dd>An <a>issuer</a> would like to provide credentials for
               end users while delegating the technical aspects of this to a
@@ -450,51 +786,6 @@ by the group should address.
             <dd>MidBank offers to provide credentials to account holders,
               such as Jane. CredentialsRUs provides a service for busniesses
               such as MidBank to use for providing such credentials.</dd>
-          </dl>
-        </section>
-
-        <section>
-          <h3 id="uc-issuing-verifiability">Credential Verifiability</h3>
-          <dl class="dl-horizontal">
-            <dt>Requirement</dt>
-            <dd>It MUST be possible for a <a>credential consumer</a> to
-              verify credentials as genuine.</dd>
-            <dt>Motivation</dt>
-            <dd>An <a>issuer</a> MUST be able to sign a credential
-              which can be verified by an arbitrary third party (<s>credential
-              consumer</s>).</dd>
-            <dt>Phase</dt>
-            <dd>Essential.</dd>
-            <dt>Scenarios</dt>
-            <dd>Company creates credential and signs with a private key.
-              Part of the signed data includes the location of the
-              corresponding public key. A third party having received the
-              credential can retrieve the public key and verify that the
-              credential signature is valid. Through other means, they can
-              choose to trust Company as a valid issuer of
-              credentials including claims that they require.</dd>
-          </dl>
-        </section>
-
-        <section>
-          <h3 id="uc-issuing-i18n">Credential Internationalization</h3>
-          <dl class="dl-horizontal">
-            <dt>Requirement</dt>
-            <dd>It MUST be possible for a <a>credential consumer</a>
-              operating in one language to understand credentials issued in a
-              different language.</dd>
-            <dt>Motivation</dt>
-            <dd>Issuers and Credential Consumers often operate in
-              different languages, and the basis of the credential MUST be
-              described in a way which supports interpreting it in multiple
-              language.</dd>
-            <dt>Phase</dt>
-            <dd>Essential.</dd>
-            <dt>Scenarios</dt>
-            <dd>Company creates a credential with claims.
-              Such claims need to either be described in multiple languages, or
-              the claim definition allows an indirection to describe the claim
-              in different languages.</dd>
           </dl>
         </section>
       </section>
@@ -817,7 +1108,7 @@ by the group should address.
                   <hr>
                   <p><em>Consuming</em><br>A customer presents a driver’s license to buy alcohol. In the same transaction, the customer buys other items and presents a SNAP card for payment. The previously presented driver’s license should be used as an authentication for both methods of payment without relying on the competence of the clerk.</p>
                   <hr>
-                  <p><em>Issuing, Consuming</em><br>The Company runs experience-based certification programs exchange of credentials could unfold in two ways: 1)  Issuing credentials on the validity of a certificate after successful assessment of candidates 2) Candidates bringing in evidence of certain activities necessary to comply with conformance requirements e.g. “I have maintained my profession by following xyz course.” <span class="ednote">Added as issuing use case (@gkellogg).</p>
+                  <p><em>Issuing, Consuming</em><br>The Company runs experience-based certification programs exchange of credentials could unfold in two ways: 1)  Issuing credentials on the validity of a certificate after successful assessment of candidates 2) Candidates bringing in evidence of certain activities necessary to comply with conformance requirements e.g. “I have maintained my profession by following xyz course.” <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Managing / Sharing</em><br>Actors: job seekers/learners/employers Purpose: Credential discovery, identification, and comparison  By means of the Web, individual learners and organizations needing to make sense of the rapidly growing credential marketplace in order to make education/training and job seeking decisions want to quickly discover, identify, and compare available credentials and credential providers based on a number of criteria including, but not limited to: (1) type of credential, (2) scope of credential application (e.g., job types, geographic areas), (3) transfer value, (4) competencies addressed; (5) mechanisms of assessment, (6) prerequisite competencies, and (7) accreditation/endorsement status.</p>
                   <hr>
@@ -825,7 +1116,7 @@ by the group should address.
                   <hr>
                   <p><em>Consuming</em><br>We are primarily interested in credentials in relation to content and annotation ownership. Our use cases center around moderation of annotations, cumulative reputation for credentialed individuals, notification (where possible) to content owners that their content is being annotated or their annotations are being replied to, as well as content and annotation distribution and publishing vetted by a distributed reputation system (permission to publish based on merit, explicit permission).</p>
                   <hr>
-                  <p><em>Consuming / Issuing</em><br>In MOOC and other on-line learning systems being able to reliably identify participants is vital to ensure the individual evaluation and certification. A participant that performs a test certified on the Web must provide his credentials to prove his identity before the test, and then to allow the system to issue a secure certificate of his results to the test.</p>
+                  <p><em>Consuming / Issuing</em><br>In MOOC and other on-line learning systems being able to reliably identify participants is vital to ensure the individual evaluation and certification. A participant that performs a test certified on the Web must provide his credentials to prove his identity before the test, and then to allow the system to issue a secure certificate of his results to the test. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Consuming</em><br>We integrate with many products and each product has it’s own credentialing system. Some use LDAP, but that is not consistent. This causes headaches because we don’t know which account to assign which user, especially if they use the account to store data. Will be nice to have a centralized Identity server (like OpenID connect)</p>
                   <hr>
@@ -847,7 +1138,7 @@ by the group should address.
                   <hr>
                   <p><em>Consuming</em><br>Like many telcos (mobile and fixed line alike) are required by law to assess the legal identity of a person before allowing them into the network.Originally only presence of the person in a shop and presentation of an identity document (ID Card, passport, etc.) was required. As it is a prerequsite e.g. even for MVNOs to sell mobile contracts (hence, SIM Cards) in supermarkets and via TV, copies of said documents, or the use of the national (proprietary) eID has seen some Adoption.</p>
                   <hr>
-                  <p><em>Issuing / Sharing</em><br>We want to enable test takers to have a digital credential that represents a score report for pursuing opportunities in education, workforce, and personal endeavors.  We can do point-to-point distribution of score reports with current technologies and standards, but we seek a digital score report credential that will allow a test taker to do controlled, multipoint display and distribution (on LinkedIn, Credly, Parchment, Monster, or Facebook, for example). Such a credential will increase the utility and user control of their score reports.  Doing this requires ubiquitous web-based standards of the type being worked on by IMS Global, the W3C Community Group, the Dublin Core, and others to ensure validity, security, privacy, efficient display and consumption, issuer control, protection of intellectual property and business model, and similar requirements.</p>
+                  <p><em>Issuing / Sharing</em><br>We want to enable test takers to have a digital credential that represents a score report for pursuing opportunities in education, workforce, and personal endeavors.  We can do point-to-point distribution of score reports with current technologies and standards, but we seek a digital score report credential that will allow a test taker to do controlled, multipoint display and distribution (on LinkedIn, Credly, Parchment, Monster, or Facebook, for example). Such a credential will increase the utility and user control of their score reports.  Doing this requires ubiquitous web-based standards of the type being worked on by IMS Global, the W3C Community Group, the Dublin Core, and others to ensure validity, security, privacy, efficient display and consumption, issuer control, protection of intellectual property and business model, and similar requirements. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Issuing / Sharing</em><br>For our organisation it would mostly be about academic credentials.</p>
                   <hr>
@@ -863,7 +1154,7 @@ by the group should address.
                   <hr>
                   <p><em>Sharing</em><br>Sharing credentials online across multiple stakeholder communities  w/out sacrificing insight to “evidence of success”, value of the outcome or earner’s privacy.  Company will provide, individuals a trusted and verifiable way to share the details of their professional accomplishments to any 3rd party recipient like employers, regulatory bodies and professional organizations.  An open standard would facilitate the transmission of this sort of data with many endpoints, so we can focus on a business model rather than data sharing protocols.</p>
                   <hr>
-                  <p><em>Issuing / Consuming</em><br>One of the most compelling use cases for Company is issuance of Loyalty Cards. When a customer applies for Loyalty Cards either online or at Point Of Sale (POS), he would need to enclose either SSN or Driving License or State ID. Though there are secure standards implemented in handling the information it would be preferable to avoid sensitive information exchange.</p>
+                  <p><em>Issuing / Consuming</em><br>One of the most compelling use cases for Company is issuance of Loyalty Cards. When a customer applies for Loyalty Cards either online or at Point Of Sale (POS), he would need to enclose either SSN or Driving License or State ID. Though there are secure standards implemented in handling the information it would be preferable to avoid sensitive information exchange. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>General</em><br>We operate in the investor / aggregation equity crowdfunding space. What we need is detailed here … <a href="http://www.paulniederer.com/2015/09/an-alternative-title-iii-retail-unaccredited-investors-and-equity-crowdfunding-solution/">http://www.paulniederer.com/2015/09/an-alternative-title-iii-retail-unaccredited-investors-and-equity-crowdfunding-solution/</a></p>
                   <hr>
@@ -872,7 +1163,7 @@ by the group should address.
               </section>
               <section>
                   <h1>5. Are there other use cases that your organization feels are important? If so, what are they?</h1>
-                  <p><em>Issuing / Sharing</em><br>Company would like to be able to strongly establish a learning identity so that when that individual moves from one institution using our software to another institution using our software (or someone else’s software) that identity and their associated accomplishments can travel with them.  We also want to be able to validate that users actually using our system is the same person who registered for courses and will receive credentials during and after assessment.</p>
+                  <p><em>Issuing / Sharing</em><br>Company would like to be able to strongly establish a learning identity so that when that individual moves from one institution using our software to another institution using our software (or someone else’s software) that identity and their associated accomplishments can travel with them.  We also want to be able to validate that users actually using our system is the same person who registered for courses and will receive credentials during and after assessment. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Consuming</em><br>We see a need for analyzing a bundle of credentials to help match or qualify a person for educational, workforce, and personal opportunities.  Doing so requires that the credentials meet the needs for our use case mentioned above in Question 4 and that the credential ecosystem can live on the web and within the web’s linked data standards and methods of data and privacy protection, security, sharing, and consumption.  We need credentials to be part of the web ecosystem to keep us from having to develop independent systems and applications for managing credentials.</p>
                   <hr>
@@ -919,7 +1210,7 @@ by the group should address.
                   <hr>
                   <p><em>Sharing</em><br>Education - proof of degrees, skills, knowledge Social Economy - Uber, Airbnb, Lyft Insurance - proof of insurance Government - proof of licenses, identity</p>
                   <hr>
-                  <p><em>Issuing</em><br>In certain cases, for legal or other reasons, it may be necessary to capture personally identifiable information as part of the credential provisioning process.  This would not apply in all cases, but the credential standard would need to optionally allow for the transmission/exchange of this information as part of the provisioning process.</p>
+                  <p><em>Issuing</em><br>In certain cases, for legal or other reasons, it may be necessary to capture personally identifiable information as part of the credential provisioning process.  This would not apply in all cases, but the credential standard would need to optionally allow for the transmission/exchange of this information as part of the provisioning process. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Issuing</em><br>Probably a knowledge-based certificate programs such as XYZ would benefit to in issuing completion of a XYZ exam.</p>
                   <hr>
@@ -983,7 +1274,7 @@ by the group should address.
                   information” in a digital token.  Closed loop cards as well.  ACH is just a set of
                   rails, with no authentication beyond RTA – so credentials are key here (waiting for
                   the first ACH breach to drive that home – with the source accounts drained and Reg
-                  E the only remedy)</p>
+                  E the only remedy) <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Consuming / Sharing</em><br>Digital Annotation. In our research we encounter several use cases from the cultural heritage domain where credentials are relevant (e.g. to uniquely identify contributors), although not always crucial.</p>
                   <hr>
@@ -1013,7 +1304,7 @@ by the group should address.
                       information than either OAuth but contains no course context (unlike LTI).  It
                       is considered too complicated for most higher-ed institutions and
                       near-impossible for the burgeoning K-12 market.</li>
-                  </ol>
+                  </ol> <span class="ednote">Added as issuing use case (@gkellogg).</span>
                   <hr>
                   <p><em>General</em><br>Ease of use, interoperability, wide acceptance</p>
                   <hr>
@@ -1081,15 +1372,19 @@ by the group should address.
       <h2>Raw content from <a href="https://docs.google.com/document/d/1GySrTXAYpwa4vDPsGE3BMA42FwIAqAyLGigKuKUTGks/edit">Google Doc</a></h2>
 
       <p><strong>Credential Operations</strong></p>
-      <p><strong>Issuing</strong></p>
-      <p><em><strong>Issuer Advertises Credential Template / aBadge Class</strong></em></p>
-      <p>The Issuer publishes a Credential Template / Badge elaborating on the requirements that must be completed to issue the credential.</p>
-      <p><em><strong>Recipient Proves Suitability for Credential</strong></em></p>
-      <p>A recipient proves that they have met the requirements necessary to acquire the credential from the issuer.</p>
-      <p><em><strong>Issuer Issues Credential to Recipient</strong></em></p>
-      <p>The issuer customizes the credential template / badge for a particular recipient. The credential/badge may be digitally signed.</p>
-      <p><em><strong>Recipient Stores Credential</strong></em></p>
-      <p>The recipient stores the credential in a credential vault or other long-term storage location.</p>
+      <div>
+          <p><strong>Issuing</strong></p>
+          <p><em><strong>Issuer Advertises Credential Template / Badge Class</strong></em></p>
+          <p>The Issuer publishes a Credential Template / Badge elaborating on the requirements that must be completed to issue the credential.</p>
+          <p><em><strong>Recipient Proves Suitability for Credential</strong></em></p>
+          <p>A recipient proves that they have met the requirements necessary to acquire the credential from the issuer.</p>
+          <p><em><strong>Issuer Issues Credential to Recipient</strong></em></p>
+          <p>The issuer customizes the credential template / badge for a particular recipient. The credential/badge may be digitally signed.</p>
+          <p><em><strong>Recipient Stores Credential</strong></em></p>
+          <p>The recipient stores the credential in a credential vault or other long-term storage location.</p>
+          <p class="ednote">Added as issuing use case (@gkellogg).</p>
+          <hr/>
+      </div>
       <p><strong>Revoking</strong></p>
       <p><em><strong>Issuer Revokes Credential</strong></em></p>
       <p>An issuer revokes a previously issued credential, after which it will no longer pass verification procedures.</p>
@@ -1129,6 +1424,7 @@ by the group should address.
           </dd>
           <dt>Motivation</dt>
           <dd>The credential definition includes descriptive metadata about the circumstances and context in which the badge is issued to the recipient. The issuer clearly defines this information so others who later view or review the credential can understand the context behind it.</dd>
+          <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
       </dl>
       <dl class="dl-horizontal">
           <dt>Publishing Requirements/dt>
@@ -1154,6 +1450,7 @@ by the group should address.
               </dd>
               <dt><em>Motivation</em></dt>
               <dd>The interoperability of credentials depends largely on market verticals defining and standardizing common terminology in publicly available machine-readable vocabulary documents.</dd>
+              <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
           </dl>
               <p><strong>Recipient Earns Credential</strong></p>
               <dl class="dl-horizontal">
@@ -1167,6 +1464,7 @@ by the group should address.
                   <dd>Pele attends the EduConf 2015 conference.</dd>
                   <dt><em>Motivation</em></dt>
                   <dd>Credentials should be able to be issued as a side-effect of performing a particular real-world action.</dd>
+                  <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
               </dl>
               <p><strong>Issuer Issues Credential to Recipient</strong></p>
               <dl class="dl-horizontal">
@@ -1190,6 +1488,7 @@ by the group should address.
                   <dd>A credential must be able to be issued to people that have disabilities (10% of the human population)</dd>
                   <dt><em>Exceptions</em></dt>
                   <dd>A recipient may not have a way to store credentials.</dd>
+                  <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
               </dl>
               <dl class="dl-horizontal">
                   <dt><strong>Bearer Credentials</strong></dt>
@@ -1198,6 +1497,7 @@ by the group should address.
                   <dd>It should be possible to prove that you have a particular attribute without leaking personally identifiable information.</dd>
                   <dt><em>Privacy</em></dt>
                   <dd>Two colluding websites should not be able to collude and build a more accurate profile of a person. There are many problems with this privacy requirement. Namely, the Open Web Platform provides multiple mechanisms like session tracking, supercookies, and email-based identifiers, that enable colluding websites to track their users across the Web. Given these existing tracking mechanisms, a bearer credential solution shouldn’t make the problem worse.</dd>
+                  <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
               </dl>
               <dl class="dl-horizontal">
                   <dt><strong>Self-claims</strong></dt>
@@ -1206,6 +1506,7 @@ by the group should address.
                   credential and includes information/evidence to support her claim.</dd>
                   <dt><em>Motivation</em></dt>
                   <dd>A recipient should be able to make a claim that asserts something specific about herself, such as a qualification, attribute, or the attainment of a particular defined achievement.</dd>
+                  <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
               </dl>
               <dl class="dl-horizontal">
                   <dt><strong>Identifier Aliasing</strong></dt>
@@ -1224,6 +1525,7 @@ by the group should address.
                   </dd>
                   <dt><em>Security</em></dt>
                   <dd>When sharing email accounts, forging credentials becomes easier/more commonplace. There are also accidental information leakage issues w/ shared credentials.</dd>
+                  <dd class="ednote">Added as issuing use case (@gkellogg).</dd>
               </dl>
                   <p><strong>Recipient Stores Credential</strong></p>
                   <dl class="dl-horizontal">

--- a/specs/source/use-cases/index.html
+++ b/specs/source/use-cases/index.html
@@ -319,10 +319,10 @@ by the group should address.
               valid.
               <img alt='Example credential creation flow' style='display:block; margin:auto' src="uc-issuing-claims.svg"/>
             </dd>
-            <dd>Jane would like to get a digitally signed credential for her checking
-              account at MidBank. MidBank offers to provide a credential asserting
-              that Jane has an account at MidBank and has access to her associated
-              checking account.</dd>
+            <dd>Jane would like to get a digitally signed credential for her
+              checking account at MidBank. MidBank offers to provide a
+              credential asserting that Jane has an account at MidBank and has
+              access to her associated checking account.</dd>
             <dd>Company is a the leading provider of electronic textbooks to
               higher-ed. A large percentage (near 75%) of integrations with our
               partner institutions launch (open) an eTextbook through the
@@ -350,42 +350,84 @@ by the group should address.
           <h3 id="uc-self-asserted-claims">Self-asserted Claims</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
-            <dd>It MUST be possible for anyone to issue a verifiable claim about themselves.</dd>
+            <dd>It MUST be possible for anyone to issue a verifiable claim
+              about themselves.</dd>
             <dt>Motivation</dt>
             <dd>An <a>entity</a>, such as an end user (<a>holder</a>),
-              wishes to make a <a>claim</a> and which they endorse themselves, acting as an
-              <a>issuer</a>.</dd>
+              wishes to make a <a>claim</a> and which they endorse themselves,
+              acting as an <a>issuer</a>.</dd>
             <dt>Phase</dt>
             <dd>Nice to have.</dd>
             <dt>Scenarios</dt>
             <dd>
-              <p>Purpose  The Country Government does not want to build a centralised repository for citizen’s self-asserted credentials such as contact details and perhaps other claimed attributes such as partner’s name, etc. Alternatively, the objective is to support the marketplace to develop an ecosystem of local or global providers that offer the citizen a range of options to choose from. A standard could enable an approach that would remove dependence on any particular technology or platform as the choice of repository for an individual’s self-asserted profile – for example, personal mobile device, open cloud service, commercial provider website.</p> 
+              <p>Purpose  The Country Government does not want to build a
+                centralised repository for citizen’s self-asserted credentials
+                such as contact details and perhaps other claimed attributes
+                such as partner’s name, etc. Alternatively, the objective is to
+                support the marketplace to develop an ecosystem of local or
+                global providers that offer the citizen a range of options to
+                choose from. A standard could enable an approach that would
+                remove dependence on any particular technology or platform as
+                the choice of repository for an individual’s self-asserted
+                profile – for example, personal mobile device, open cloud
+                service, commercial provider website.</p>
               <p>Agency and citizen requirements:</p>
               <ul>
-              <li>The government agency requires an applicant’s contact details – that is self-asserted credentials; for example, email address, mobile phone, postal address, to complete their registration process for the agency’s online service.</li>
-              <li>If the customer changes one of these attributes, the agency would like the option of being notified.</li>
-              <li>The citizen wants the means to select specific contact details from their existing self-managed profile to share with this particular government agency.</li>
-              <li>If the citizen changes one of these attributes they want to be able to simply update their profile without explicitly notifying each government agency or organisation.</li>
+              <li>The government agency requires an applicant’s
+                contact details – that is self-asserted credentials; for
+                example, email address, mobile phone, postal address, to
+                complete their registration process for the agency’s online
+                service.</li>
+              <li>If the customer changes one of these attributes,
+                the agency would like the option of being notified.</li>
+              <li>The citizen wants the means to select specific contact
+                details from their existing self-managed profile to share with
+                this particular government agency.</li>
+              <li>If the citizen changes one of these attributes they
+                want to be able to simply update their profile without
+                explicitly notifying each government agency or
+                organisation.</li>
               </ul>
               <p>Use case – register with service provider</p>
               <ol>
-                <li>Jane applies to the government agency for a social welfare entitlement.</li>
-                <li>The agency requires Jane to authenticate and she uses her federated login credentials.</li>
-                <li>The agency requests Jane’s full name, date of birth, citizenship and validated bank account.</li>
-                <li>Jane opts to assert her online core identity, citizenship and validated bank account credentials from the authoritative providers.</li>
+                <li>Jane applies to the government agency for a
+                  social welfare entitlement.</li>
+                <li>The agency requires Jane to authenticate and she
+                  uses her federated login credentials.</li>
+                <li>The agency requests Jane’s full name, date of birth,
+                  citizenship and validated bank account.</li>
+                <li>Jane opts to assert her online core identity,
+                  citizenship and validated bank account credentials from the
+                  authoritative providers.</li>
                 <li>The agency requests Jane’s contact details.</li>
                 <li>Jane opts to provide these from her online profile.</li>
-                <li>The agency initiates a request to a credential/attribute brokering service.</li>
-                <li>The brokering service checks Jane’s authentication token.</li>
-                <li>The brokering service retrieves Jane’s identity, citizenship and validated bank account from the respective authoritative credential/attribute providers.</li>
-                <li>The brokering service retrieves Jane’s profile from her preferred contact details repository mechanism (personal mobile device, open cloud service, commercial provider website, etc.).</li>
+                <li>The agency initiates a request to a
+                  credential/attribute brokering service.</li>
+                <li>The brokering service checks Jane’s authentication
+                  token.</li>
+                <li>The brokering service retrieves Jane’s identity,
+                  citizenship and validated bank account from the respective
+                  authoritative credential/attribute providers.</li>
+                <li>The brokering service retrieves Jane’s profile from
+                  her preferred contact details repository mechanism (personal
+                  mobile device, open cloud service, commercial provider
+                  website, etc.).</li>
                 <li>Jane selects some specific contact details.</li>
-                <li>Jane provides information sharing consent (if not previously provided) to share identity, citizenship, bank account and contact details with the requesting government agency.</li>
-                <li>The brokering service returns the respective credentials to the requesting agency.</li>
-                <li>The requesting agency provides Jane with the requested welfare entitlement.</li>
+                <li>Jane provides information sharing consent
+                  (if not previously provided) to share identity, citizenship,
+                  bank account and contact details with the requesting
+                  government agency.</li>
+                <li>The brokering service returns the respective
+                  credentials to the requesting agency.</li>
+                <li>The requesting agency provides Jane with the
+                  requested welfare entitlement.</li>
               </ol>
             </dd>
-            <dd>Related use cases  Other use cases for contact details would include initial create and manage contact details profile, service provider checks for contact details credential change, citizen notifies multiple service providers about a credential change.</dd>
+            <dd>Related use cases  Other use cases for contact details
+              would include initial create and manage contact details profile,
+              service provider checks for contact details credential change,
+              citizen notifies multiple service providers about a credential
+              change.</dd>
           </dl>
         </section>
 
@@ -393,15 +435,21 @@ by the group should address.
           <h3 id="uc-issuing-delegation">Delegating Credential Creation</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
-            <dd>It MUST be possible for an <a>issuer</a> to delegate issuing credentials to end users.</dd>
+            <dd>It MUST be possible for an <a>issuer</a> to
+              delegate issuing credentials to end users.</dd>
             <dt>Motivation</dt>
-            <dd>An <a>issuer</a> would like to provide credentials for end users while delegating the technical aspects of this to a third party. A credential authority would be able to authorize 1 or more credential issuers which would in turn be able to issue secure credentials that are accepted as valid and acceptable by consumers of the authority's credentials.</dd>
+            <dd>An <a>issuer</a> would like to provide credentials for
+              end users while delegating the technical aspects of this to a
+              third party. A credential authority would be able to authorize 1
+              or more credential issuers which would in turn be able to issue
+              secure credentials that are accepted as valid and acceptable by
+              consumers of the authority's credentials.</dd>
             <dt>Phase</dt>
             <dd>Nice to have.</dd>
             <dt>Scenarios</dt>
-            <dd>MidBank offers to provide credentials to account holders, such as Jane.
-              CredentialsRUs provides a service for busniesses such as MidBank to use
-              for providing such credentials.</dd>
+            <dd>MidBank offers to provide credentials to account holders,
+              such as Jane. CredentialsRUs provides a service for busniesses
+              such as MidBank to use for providing such credentials.</dd>
           </dl>
         </section>
 
@@ -409,9 +457,12 @@ by the group should address.
           <h3 id="uc-issuing-verifiability">Credential Verifiability</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
-            <dd>It MUST be possible for a <a>credential consumer</a> to verify credentials as genuine.</dd>
+            <dd>It MUST be possible for a <a>credential consumer</a> to
+              verify credentials as genuine.</dd>
             <dt>Motivation</dt>
-            <dd>An <a>issuer</a> MUST be able to sign a credential which can be verified by an arbitrary third party (<s>credential consumer</s>).</dd>
+            <dd>An <a>issuer</a> MUST be able to sign a credential
+              which can be verified by an arbitrary third party (<s>credential
+              consumer</s>).</dd>
             <dt>Phase</dt>
             <dd>Essential.</dd>
             <dt>Scenarios</dt>
@@ -429,15 +480,21 @@ by the group should address.
           <h3 id="uc-issuing-i18n">Credential Internationalization</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
-            <dd>It MUST be possible for a <a>credential consumer</a> operating in one language to understand credentials issued in a different language.</dd>
+            <dd>It MUST be possible for a <a>credential consumer</a>
+              operating in one language to understand credentials issued in a
+              different language.</dd>
             <dt>Motivation</dt>
-            <dd>Issuers and Credential Consumers often operate in different languages, and the basis of the credential MUST be described in a way which supports interpreting it in multiple language.</dd>
+            <dd>Issuers and Credential Consumers often operate in
+              different languages, and the basis of the credential MUST be
+              described in a way which supports interpreting it in multiple
+              language.</dd>
             <dt>Phase</dt>
             <dd>Essential.</dd>
             <dt>Scenarios</dt>
             <dd>Company creates a credential with claims.
-              Such claims need to either be described in multiple languages,
-              or the claim definition allows an indirection to describe the claim in different languages.</dd>
+              Such claims need to either be described in multiple languages, or
+              the claim definition allows an indirection to describe the claim
+              in different languages.</dd>
           </dl>
         </section>
       </section>

--- a/specs/source/use-cases/index.html
+++ b/specs/source/use-cases/index.html
@@ -336,6 +336,13 @@ by the group should address.
               a license (<a>credential</a>) for the eTextbook if non currently
               exists. Finally it presents the eTextbook contents to the
               student.</dd>
+            <dd>The Company runs experience-based certification programs
+              issuing credentials could unfold in two ways: 1) Issuing
+              credentials on the validity of a certificate after successful
+              assessment of candidates 2) Candidates bringing in evidence of
+              certain activities necessary to comply with conformance
+              requirements e.g. “I have maintained my profession by following
+              xyz course.”</dd>
           </dl>
         </section>
 
@@ -383,7 +390,7 @@ by the group should address.
         </section>
 
         <section>
-          <h3 id="uc-issuing-lti">Delegating Credential Creating</h3>
+          <h3 id="uc-issuing-delegation">Delegating Credential Creation</h3>
           <dl class="dl-horizontal">
             <dt>Requirement</dt>
             <dd>It MUST be possible for an <a>issuer</a> to delegate issuing credentials to end users.</dd>
@@ -395,6 +402,42 @@ by the group should address.
             <dd>MidBank offers to provide credentials to account holders, such as Jane.
               CredentialsRUs provides a service for busniesses such as MidBank to use
               for providing such credentials.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-issuing-verifiability">Credential Verifiability</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for a <a>credential consumer</a> to verify credentials as genuine.</dd>
+            <dt>Motivation</dt>
+            <dd>An <a>issuer</a> MUST be able to sign a credential which can be verified by an arbitrary third party (<s>credential consumer</s>).</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>Company creates credential and signs with a private key.
+              Part of the signed data includes the location of the
+              corresponding public key. A third party having received the
+              credential can retrieve the public key and verify that the
+              credential signature is valid. Through other means, they can
+              choose to trust Company as a valid issuer of
+              credentials including claims that they require.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="uc-issuing-i18n">Credential Internationalization</h3>
+          <dl class="dl-horizontal">
+            <dt>Requirement</dt>
+            <dd>It MUST be possible for a <a>credential consumer</a> operating in one language to understand credentials issued in a different language.</dd>
+            <dt>Motivation</dt>
+            <dd>Issuers and Credential Consumers often operate in different languages, and the basis of the credential MUST be described in a way which supports interpreting it in multiple language.</dd>
+            <dt>Phase</dt>
+            <dd>Essential.</dd>
+            <dt>Scenarios</dt>
+            <dd>Company creates a credential with claims.
+              Such claims need to either be described in multiple languages,
+              or the claim definition allows an indirection to describe the claim in different languages.</dd>
           </dl>
         </section>
       </section>
@@ -692,7 +735,7 @@ by the group should address.
                   <hr>
                   <p><em>General</em><br>Company provides services to hundreds of thousands of financial decision makers around the globe, and uses proprietary authentication mechanisms to provide access to these services. Many of our clients would benefit from being able to leverage our authentication mechanisms in their own web applications, whether those applications connect to Company services or are independent, but today it is difficult to achieve that integration due to the lack of standardization in this area. We also have a rapidly growing community of third-party application developers who provide applications to our clients, and integration of those applications with our authentication mechanisms is complicated by the proprietary nature of the mechanisms.  If Company was able to offer a standards-based credential provider that was usable by our clients in any compatible browser and by any compatible application, using only W3C Recommendation-defined APIs and protocols, this would be very beneficial to our ecosystem.</p>
                   <hr>
-                  <p><em>Issuing</em><br>We wish to issue personal credentials to people who have met our requirements (exam or other evaluation).  We need these credentials to be verifiable as genuine by third parties. We need this to work in multiple languages,</p>
+                  <p><em>Issuing</em><br>We wish to issue personal credentials to people who have met our requirements (exam or other evaluation).  We need these credentials to be verifiable as genuine by third parties. We need this to work in multiple languages. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
                   <p><em>Issuing</em><br>Company is a the leading provider of electronic textbooks to higher-ed.  A large percentage (near 75%) of integrations with our partner institutions launch (open) an eTextbook through the IMSGlobal standard: Learning Tools Interoperability (LTI).  At present Company processes about two million LTI launches per month.  So the primary use case is: Student logs on to their learning system (LMS) and clicks an eTextbook icon that they would like to study.  Our LTI integration broker needs to subscribe the student if it’s their first visit.  Furthermore it needs to issue a license for the eTextbook if non currently exists.  Finally it presents the eTextbook contents to the student. <span class="ednote">Added as issuing use case (@gkellogg).</span></p>
                   <hr>
@@ -717,7 +760,7 @@ by the group should address.
                   <hr>
                   <p><em>Consuming</em><br>A customer presents a driver’s license to buy alcohol. In the same transaction, the customer buys other items and presents a SNAP card for payment. The previously presented driver’s license should be used as an authentication for both methods of payment without relying on the competence of the clerk.</p>
                   <hr>
-                  <p><em>Issuing, Consuming</em><br>The Company runs experience-based certification programs exchange of credentials could unfold in two ways: 1)  Issuing credentials on the validity of a certificate after successful assessment of candidates 2) Candidates bringing in evidence of certain activities necessary to comply with conformance requirements e.g. “I have maintained my profession by following xyz course”</p>
+                  <p><em>Issuing, Consuming</em><br>The Company runs experience-based certification programs exchange of credentials could unfold in two ways: 1)  Issuing credentials on the validity of a certificate after successful assessment of candidates 2) Candidates bringing in evidence of certain activities necessary to comply with conformance requirements e.g. “I have maintained my profession by following xyz course.” <span class="ednote">Added as issuing use case (@gkellogg).</p>
                   <hr>
                   <p><em>Managing / Sharing</em><br>Actors: job seekers/learners/employers Purpose: Credential discovery, identification, and comparison  By means of the Web, individual learners and organizations needing to make sense of the rapidly growing credential marketplace in order to make education/training and job seeking decisions want to quickly discover, identify, and compare available credentials and credential providers based on a number of criteria including, but not limited to: (1) type of credential, (2) scope of credential application (e.g., job types, geographic areas), (3) transfer value, (4) competencies addressed; (5) mechanisms of assessment, (6) prerequisite competencies, and (7) accreditation/endorsement status.</p>
                   <hr>


### PR DESCRIPTION
- Remove redundant and un-informative credential creation workflow diagrams.
- Add most remaining issuer use cases.
