### PR TITLE
Fixed the way we use respecEvents to match new model

### DIFF
--- a/specs/source/common/common.js
+++ b/specs/source/common/common.js
@@ -1,4 +1,7 @@
 /* Web Payments Community Group common spec JavaScript */
+/* globals respecConfig, $, require */
+/* exported linkCrossReferences, restrictReferences, fixIncludes */
+
 var opencreds = {
   // Add as the respecConfig localBiblio variable
   // Extend or override global respec references
@@ -95,6 +98,7 @@ var termLists = [] ;
 var termsReferencedByTerms = [] ;
 
 function restrictReferences(utils, content) {
+    "use strict";
     var base = document.createElement("div");
     base.innerHTML = content;
 
@@ -116,15 +120,19 @@ function restrictReferences(utils, content) {
     var containerID = $container.makeID("", "terms") ;
     termLists.push(containerID) ;
 
-    // add a handler to come in after all the definitions are resolved
-    //
-    // New logic: If the reference is within a 'dl' element of
-    // class 'termlist', and if the target of that reference is
-    // also within a 'dl' element of class 'termlist', then
-    // consider it an internal reference and ignore it.
+    return (base.innerHTML);
+}
+// add a handler to come in after all the definitions are resolved
+//
+// New logic: If the reference is within a 'dl' element of
+// class 'termlist', and if the target of that reference is
+// also within a 'dl' element of class 'termlist', then
+// consider it an internal reference and ignore it.
 
+require(["core/pubsubhub"], function(respecEvents) {
+    "use strict";
     respecEvents.sub('end', function(message) {
-        if (message == 'core/link-to-dfn') {
+        if (message === 'core/link-to-dfn') {
             // all definitions are linked; find any internal references
             $(".termlist a.internalDFN").each(function() {
                 var $r = $(this);
@@ -159,7 +167,7 @@ function restrictReferences(utils, content) {
                             clearRefs(item);
                         }
                     });
-                };
+                }
                 // make sure this term doesn't get removed
                 if (termNames[theTerm]) {
                     delete termNames[theTerm];
@@ -195,5 +203,4 @@ function restrictReferences(utils, content) {
             });
         }
     });
-    return (base.innerHTML);
-}
+});


### PR DESCRIPTION
Eliminates a warning because ReSpec changed the way it exports events.
