### PR TITLE
Cleaned up JWT Example

### DIFF
--- a/specs/source/claims-data-model/index.html
+++ b/specs/source/claims-data-model/index.html
@@ -534,12 +534,12 @@ WebIDL.</p>
     "id": "did:ebfeb1f712ebc6f1c276e12ec21",
     "ageOver": 21
   },
-  "signature": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiO\
-iJodHRwczovL2Rtdi5leGFtcGxlLmdvdiIsImlhdCI6MTI2MjMwNDAwMCwiZXhwI\
-joxNDgzMjI4ODAwLCJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJzdWIiOiJkaWQ6Z\
-WJmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwiaWQiOiJkaWQ6ZWJmZWIxZjcxM\
-mViYzZmMWMyNzZlMTJlYzIxIiwiYWdlT3ZlciI6IjIxIn0.YIk9tKxeVylqtZOpt\
-tGzOBuqX5DH-RV7jCwybPzcQeU"
+  "signature": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOi\
+JodHRwczovL2Rtdi5leGFtcGxlLmdvdiIsImlhdCI6MTI2MjMwNDAwMCwiZXhwIj\
+oxNDgzMjI4ODAwLCJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJzdWIiOiJkaWQ6ZW\
+JmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwiaWQiOiJkaWQ6ZWJmZWIxZjcxMm\
+ViYzZmMWMyNzZlMTJlYzIxIiwiYWdlT3ZlciI6MjF9.iXWMxCzjDd6TH2zQ6MO5an\
+5ECcswBmR3FAj90zYoF6E"
 }</pre>
 
         <p>

--- a/specs/source/claims-data-model/index.html
+++ b/specs/source/claims-data-model/index.html
@@ -521,6 +521,10 @@ WebIDL.</p>
   "type": ["Credential", "ProofOfAgeCredential"],
   "issuer": "https://dmv.example.gov",
   "issued": "2010-01-01",
+  "header": {
+    "alg": "HS256",
+    "type": "JWT"
+  },
   "claim": {
     "iss": "https://dmv.example.gov",
     "iat": 1262304000,
@@ -530,16 +534,12 @@ WebIDL.</p>
     "id": "did:ebfeb1f712ebc6f1c276e12ec21",
     "ageOver": 21
   },
-  "signature": {
-    "type": "HS256",
-    "key": "qwertyuiopasdfghjklzxcvbnm123456",
-    "JWS": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiO\
+  "signature": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiO\
 iJodHRwczovL2Rtdi5leGFtcGxlLmdvdiIsImlhdCI6MTI2MjMwNDAwMCwiZXhwI\
 joxNDgzMjI4ODAwLCJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJzdWIiOiJkaWQ6Z\
 WJmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwiaWQiOiJkaWQ6ZWJmZWIxZjcxM\
 mViYzZmMWMyNzZlMTJlYzIxIiwiYWdlT3ZlciI6IjIxIn0.YIk9tKxeVylqtZOpt\
 tGzOBuqX5DH-RV7jCwybPzcQeU"
-  }
 }</pre>
 
         <p>


### PR DESCRIPTION
I cleaned up the JWT example. I added a header section, moved the alg and type to that as is more idiomatic and removed the key from the signature as that wouldn't travel with the credential. The signature would be submitted to the issuer to verify. The signature should verify against the previous key of "qwertyuiopasdfghjklzxcvbnm123456". You can combine the lines in the signature and verify it at https://jwt.io/#debugger-io.
